### PR TITLE
Refactor constructors and endpoints, improve null handling

### DIFF
--- a/Core.Application/Features/Scraping/Cuevana/Cuevana3.ch/Commands/GetAllCuevanaMovies/GetAllCuevanaMoviesCommand.cs
+++ b/Core.Application/Features/Scraping/Cuevana/Cuevana3.ch/Commands/GetAllCuevanaMovies/GetAllCuevanaMoviesCommand.cs
@@ -13,28 +13,16 @@ namespace Core.Application.Features.Scraping.Cuevana.Cuevana3.ch.Commands.GetAll
 
     }
 
-    public class GetAllCuevanaMoviesCommandHandler : IRequestHandler<GetAllCuevanaMoviesCommand, bool>
+    public class GetAllCuevanaMoviesCommandHandler(IMovieWebRepository movieWebRepository, IMovie_MovieWebRepository movie_MovieWebRepository, IMovieRepository movieRepository, GetTmdbData getTmdbData, IGenre_MovieRepository genre_MovieRepository, IGenreRepository genreRepository, IMapper mapper) : IRequestHandler<GetAllCuevanaMoviesCommand, bool>
     {
-        private readonly IMovieWebRepository _movieWebRepository;
-        private readonly IMovie_MovieWebRepository _movie_MovieWebRepository;
-        private readonly IMovieRepository _movieRepository;
-        private readonly IGenre_MovieRepository _genre_MovieRepository;
-        private readonly IGenreRepository _genreRepository;
+        private readonly IMovieWebRepository _movieWebRepository = movieWebRepository;
+        private readonly IMovie_MovieWebRepository _movie_MovieWebRepository = movie_MovieWebRepository;
+        private readonly IMovieRepository _movieRepository = movieRepository;
+        private readonly IGenre_MovieRepository _genre_MovieRepository = genre_MovieRepository;
+        private readonly IGenreRepository _genreRepository = genreRepository;
 
-        private readonly GetTmdbData _getTmdbData;
-        private readonly IMapper _mapper;
-
-        public GetAllCuevanaMoviesCommandHandler(IMovieWebRepository movieWebRepository, IMovie_MovieWebRepository movie_MovieWebRepository, IMovieRepository movieRepository, GetTmdbData getTmdbData, IGenre_MovieRepository genre_MovieRepository, IGenreRepository genreRepository, IMapper mapper)
-        {
-            _movieWebRepository = movieWebRepository;
-            _movie_MovieWebRepository = movie_MovieWebRepository;
-            _movieRepository = movieRepository;
-            _getTmdbData = getTmdbData;
-            _genre_MovieRepository = genre_MovieRepository;
-            _genreRepository = genreRepository;
-            _mapper = mapper;
-        }
-
+        private readonly GetTmdbData _getTmdbData = getTmdbData;
+        private readonly IMapper _mapper = mapper;
 
         public async Task<bool> Handle(GetAllCuevanaMoviesCommand request, CancellationToken cancellationToken)
         {

--- a/Core.Application/Features/Scraping/PelisPlusLat/Commands/GetPelisPlusLatMovies/GetPelisPlusLatMoviesCommand.cs
+++ b/Core.Application/Features/Scraping/PelisPlusLat/Commands/GetPelisPlusLatMovies/GetPelisPlusLatMoviesCommand.cs
@@ -21,8 +21,6 @@ namespace Core.Application.Features.Scraping.PelisPlusLat.Commands.GetPelisPlusL
         ILogger<GetPelisPlusLatMoviesCommandHandler> logger,
         IMapper mapper) : IRequestHandler<GetPelisPlusLatMoviesCommand, bool>
     {
-        private readonly int DB_WEB_ID = 1;
-        private readonly string ORIGINAL_URI = "https://www12.pelisplushd.lat";
         private readonly IMovieWebRepository _movieWebRepository = movieWebRepository;
         private readonly IMovie_MovieWebRepository _movie_MovieWebRepository = movie_MovieWebRepository;
         private readonly IMovieRepository _movieRepository = movieRepository;
@@ -32,7 +30,7 @@ namespace Core.Application.Features.Scraping.PelisPlusLat.Commands.GetPelisPlusL
 
         public async Task<bool> Handle(GetPelisPlusLatMoviesCommand request, CancellationToken cancellationToken)
         {
-            var PelisPlusLatMovies = new Services.WebScrapers.MovieESWebsites.PelisPluslat.GetPelisPlusLatMovies(DB_WEB_ID, ORIGINAL_URI);
+            var PelisPlusLatMovies = new Services.WebScrapers.MovieESWebsites.PelisPluslat.GetPelisPlusLatMovies(1, "https://www12.pelisplushd.lat");
             try
             {
                 int count = PelisPlusLatMovies.GetPelisplushdPagination();

--- a/Core.Application/Features/SearchMovieModule/Queries/HomeModule/GetHomePageData/GetHomePageDataQuery.cs
+++ b/Core.Application/Features/SearchMovieModule/Queries/HomeModule/GetHomePageData/GetHomePageDataQuery.cs
@@ -43,7 +43,7 @@ namespace Core.Application.Features.SearchMovieModule.Queries.HomeModule.GetHome
                 foreach (var genre in genres)
                 {
                     var selectedMovies = new List<Movie>();
-                    foreach (var x in genre.GenreMovie)
+                    foreach (var x in genre.GenreMovie ?? [])
                     {
                         var movieToAdd = await _movieRepository.GetByIdAsync(x.MovieID);
 

--- a/Infraestructure.Persistence/Repositories/MovieRepository.cs
+++ b/Infraestructure.Persistence/Repositories/MovieRepository.cs
@@ -73,7 +73,8 @@ namespace Infrastructure.Persistence.Repositories
             foreach (var keyword in searchKeywords)
             {
                 var moviesMatchingKeyword = await _dbContext.Set<Movie>()
-                    .Where(x => x != null && x.Title.ToLower().Contains(keyword)).Include(x => x.GenreMovie)
+                    .Where(x => x != null && EF.Functions.Like(x.Title, $"%{keyword}%"))
+                    .Include(x => x.GenreMovie)
                     .ToListAsync();
                 responseMovies.AddRange(moviesMatchingKeyword);
             }

--- a/Presentation.KuhakuCentral/Controllers/V1/WebScrapingModule/WebScrapingModuleController.cs
+++ b/Presentation.KuhakuCentral/Controllers/V1/WebScrapingModule/WebScrapingModuleController.cs
@@ -13,40 +13,26 @@ namespace KuhakuCentral.Controllers.V1.WebScrapingModule
     public class WebScrapingModuleController : BaseApi
     {
 
-        [HttpGet("Cuevana3.ch")]
+        [HttpGet("ScrapPage")]
         [Authorize(Roles = "Owner")]
         [Consumes(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [SwaggerOperation(
-        Summary = "Web Scraping at Cuevana3.ch",
-        Description = "Get all movies from Cuevana3.ch and send them to the Database"
+        Summary = "Web Scraping",
+        Description = "Get all movies from Page and send them to the Database"
         )]
-        public async Task<IActionResult> ScrapCuevana3CH()
+        public async Task<IActionResult> ScrapPage(int Id)
         {
-            await Mediator.Send(new GetAllCuevanaMoviesCommand());
-            return Ok(new GenericApiResponse<string>
+            switch(Id)
             {
-                Payload = "Done",
-                Message = HttpStatusCode.Accepted.ToString(),
-                Statuscode = 200,
-                Success = true
-            });
-        }
-
-
-        [HttpGet("Pelisplushd.lat")]
-        [Authorize(Roles = "Owner")]
-        [Consumes(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        [SwaggerOperation(
-            Summary = "Web Scraping at PelisPlus.lat",
-            Description = "Get all movies from PelisPlus.lat and send them to the Database"
-        )]
-        public async Task<IActionResult> ScrapPelisPlusLat()
-        {
-            await Mediator.Send(new GetPelisPlusLatMoviesCommand());
+                case 1:
+                    await Mediator.Send(new GetAllCuevanaMoviesCommand());
+                    break;
+                case 2:
+                    await Mediator.Send(new GetPelisPlusLatMoviesCommand());
+                    break;
+            }
             return Ok(new GenericApiResponse<string>
             {
                 Payload = "Done",


### PR DESCRIPTION
Refactor constructors and endpoints, improve null handling

Refactored `GetAllCuevanaMoviesCommandHandler` constructor to use property initializers. Removed constants in `GetPelisPlusLatMoviesCommand.cs` and used their values directly. Added null-coalescing operator in `GetHomePageDataQuery.cs` to handle potential null values. Updated `Where` clause in `MovieRepository.cs` to use `EF.Functions.Like` for better performance. Generalized scraping endpoint in `WebScrapingModuleController.cs` to a single endpoint with an `Id` parameter.