### PR TITLE
Update string parameter in GetAllWithIncludes method

### DIFF
--- a/Core.Application/Features/SearchMovieModule/Queries/HomeModule/GetHomePageData/GetHomePageDataQuery.cs
+++ b/Core.Application/Features/SearchMovieModule/Queries/HomeModule/GetHomePageData/GetHomePageDataQuery.cs
@@ -38,7 +38,7 @@ namespace Core.Application.Features.SearchMovieModule.Queries.HomeModule.GetHome
             };
             try
             {
-                var genres = await _genreRepository.GetAllWithIncludes(["Genre_Movie"]);
+                var genres = await _genreRepository.GetAllWithIncludes(["GenreMovie"]);
 
                 foreach (var genre in genres)
                 {


### PR DESCRIPTION
Update string parameter in GetAllWithIncludes method

Changed the string parameter in the GetAllWithIncludes method of
the _genreRepository object from "Genre_Movie" to "GenreMovie"
to match the new naming convention.