### PR TITLE
Enforce Owner role for ScrapPage method

### DIFF
--- a/Presentation.KuhakuCentral/Controllers/V1/WebScrapingModule/WebScrapingModuleController.cs
+++ b/Presentation.KuhakuCentral/Controllers/V1/WebScrapingModule/WebScrapingModuleController.cs
@@ -16,7 +16,7 @@ namespace KuhakuCentral.Controllers.V1.WebScrapingModule
     {
 
         [HttpGet("ScrapPage")]
-        //[Authorize(Roles = "Owner")]
+        [Authorize(Roles = "Owner")]
         [Consumes(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]


### PR DESCRIPTION
Enforce Owner role for ScrapPage method

Uncommented [Authorize(Roles = "Owner")] attribute in the ScrapPage method of WebScrapingModuleController. This change restricts access to the method, ensuring only users with the "Owner" role can access it, thereby enhancing security.