### PR TITLE
Handle missing movies gracefully in repository methods

### DIFF
--- a/Core.Application/Features/Scraping/Cuevana/Cuevana3.ch/Commands/GetAllCuevanaMovies/GetAllCuevanaMoviesCommand.cs
+++ b/Core.Application/Features/Scraping/Cuevana/Cuevana3.ch/Commands/GetAllCuevanaMovies/GetAllCuevanaMoviesCommand.cs
@@ -49,7 +49,10 @@ namespace Core.Application.Features.Scraping.Cuevana.Cuevana3.ch.Commands.GetAll
                     {
                         var movieWebAdd = await _movieWebRepository.AddAsync(_mapper.Map<MovieWeb>(movie));
                         var movieRepositoryId = await _movieRepository.GetIdByTmdbId(movie.TMDBTempID);
-
+                        if(movieRepositoryId == 0)
+                        {
+                            continue;
+                        }
                         await _movie_MovieWebRepository.AddAsync(new MovieMovieWeb
                         {
                             MovieID = movieRepositoryId,

--- a/Infraestructure.Persistence/Repositories/MovieRepository.cs
+++ b/Infraestructure.Persistence/Repositories/MovieRepository.cs
@@ -45,7 +45,8 @@ namespace Infrastructure.Persistence.Repositories
 
         public async Task<int> GetIdByTmdbId(int TmdbId)
         {
-            return (await _dbContext.Set<Movie>().FirstAsync(x => x.TMDBID == TmdbId)).ID;
+            var movie = await _dbContext.Set<Movie>().FirstOrDefaultAsync(x => x.TMDBID == TmdbId);
+            return movie?.ID ?? 0;
         }
 
         public async Task<Movie> GetMovieInfo(int MovieId)


### PR DESCRIPTION
Handle missing movies gracefully in repository methods

The changes in `GetAllCuevanaMoviesCommand.cs` add a conditional check to skip processing for movies that do not have a corresponding entry in the movie repository.

In `MovieRepository.cs`, the `GetIdByTmdbId` method is modified to return 0 if no movie is found with the given `TmdbId`, instead of throwing an exception. This is achieved by using `FirstOrDefaultAsync` instead of `FirstAsync`.